### PR TITLE
Set default locale to English

### DIFF
--- a/app/views/camps/_dont_miss_out.erb
+++ b/app/views/camps/_dont_miss_out.erb
@@ -3,6 +3,7 @@
   if lockdown_info.present?
       time_left = distance_of_time_in_words(Time.now, lockdown_info[1], false, highest_measures: 2)
     action = t("dont_miss_out.actions.#{lockdown_info[0]}")
+  end
 %>
 <div class="row alignedrow">
   <p class="notice" style='float: <%=t :lang_direction %>' dir='<%=t :html_direction %>'>

--- a/app/views/camps/_dont_miss_out.erb
+++ b/app/views/camps/_dont_miss_out.erb
@@ -1,7 +1,7 @@
 <%
   lockdown_info = Lockdown.instance.next(except)
   if lockdown_info.present?
-      time_left = distance_of_time_in_words(Time.now, lockdown_info[1], false, highest_measures: 2)
+    time_left = distance_of_time_in_words(Time.now, lockdown_info[1], false, highest_measures: 2)
     action = t("dont_miss_out.actions.#{lockdown_info[0]}")
   end
 %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,7 +18,7 @@ module Firestarter
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
-    config.i18n.default_locale = :he
+    config.i18n.default_locale = :en
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     Rails.application.config.x.firestarter_settings = config_for(:firestarter_settings)


### PR DESCRIPTION
I reckon it'll be much easier for most of the hackers there to work with a default-english app; I had a tough time navigating the hebrew when it first showed up, and it's a bit of trouble to switch it over